### PR TITLE
`Usability`: Add filtering and search to Teams and Team Detail pages

### DIFF
--- a/src/main/webapp/src/components/AnalysisFeed.tsx
+++ b/src/main/webapp/src/components/AnalysisFeed.tsx
@@ -335,9 +335,7 @@ const AnalysisFeed = ({ chunks, isDevMode = false }: AnalysisFeedProps) => {
           <div className="flex items-center justify-between">
             <h3 className="text-lg font-semibold">
               Analysis History
-              {hasActiveFilters
-                ? ` (${filteredTeamChunks.length} of ${teamChunks.length} chunks)`
-                : ` (${teamChunks.length} chunks)`}
+              {hasActiveFilters ? ` (${filteredTeamChunks.length} of ${teamChunks.length} chunks)` : ` (${teamChunks.length} chunks)`}
             </h3>
             {hasActiveFilters && (
               <button

--- a/src/main/webapp/src/components/TeamsList.tsx
+++ b/src/main/webapp/src/components/TeamsList.tsx
@@ -3,7 +3,20 @@ import type { TemplateAuthorInfo } from '@/data/dataLoaders';
 import { Badge } from '@/components/ui/badge';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { AlertTriangle, ArrowLeft, Play, Square, RefreshCw, Trash2, CodeXml, GitBranch, Pencil, ChevronDown, Search, X } from 'lucide-react';
+import {
+  AlertTriangle,
+  ArrowLeft,
+  Play,
+  Square,
+  RefreshCw,
+  Trash2,
+  CodeXml,
+  GitBranch,
+  Pencil,
+  ChevronDown,
+  Search,
+  X,
+} from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import {
   AlertDialog,


### PR DESCRIPTION
## Summary
- Add search and filter functionality to the Teams overview page
- Add search and filter functionality to the Team Detail page
- Real-time filtering as the user types

Closes #175