### PR TITLE
`Usability`: Persist exercise URL and pair programming setting in browser storage

### DIFF
--- a/src/main/webapp/src/components/StartAnalysis.tsx
+++ b/src/main/webapp/src/components/StartAnalysis.tsx
@@ -97,7 +97,7 @@ const StartAnalysis = ({ onStart }: StartAnalysisProps) => {
       // Store server URL in localStorage for later usage
       try {
         if (typeof window !== 'undefined' && window.localStorage) {
-          window.localStorage.setItem('artemis_server_url', baseUrl);
+          window.localStorage.setItem('harmonia.serverUrl', baseUrl);
         }
       } catch {
         // Ignore errors

--- a/src/main/webapp/src/components/TeamDetail.tsx
+++ b/src/main/webapp/src/components/TeamDetail.tsx
@@ -56,7 +56,7 @@ const TeamDetail = ({
     let baseUrl: string | null = null;
     try {
       if (typeof window !== 'undefined' && window.localStorage) {
-        baseUrl = window.localStorage.getItem('artemis_server_url');
+        baseUrl = window.localStorage.getItem('harmonia.serverUrl');
       }
     } catch {
       baseUrl = null;


### PR DESCRIPTION
## Description

Closes #201

Persist the Artemis exercise URL and pair programming setting in browser storage so they are pre-filled when the user navigates back. Remove the hardcoded default URL.

## Changes

- Initialize `exerciseUrl` from `localStorage` key `harmonia.exerciseUrl` (fallback: empty string) instead of a hardcoded Artemis URL
- Initialize `pairProgrammingMode` from `localStorage` key `harmonia.pairProgrammingMode` (fallback: `yes`), with validation that the stored value is `yes` or `no`
- Persist both values to `localStorage` on every change via their `onChange`/`onValueChange` handlers
- Uses the same SSR-safe try-catch pattern already present in the file

## Test plan

- [ ] Open the app — exercise URL field should be empty on first use
- [ ] Enter a URL and set pair programming to "No"
- [ ] Navigate away, then return — both values should be pre-filled
- [ ] Clear localStorage — values should reset to defaults (empty URL, "Yes")