### PR TITLE
`Performance`: Parallelize AI analysis phase of streaming pipeline

### DIFF
--- a/src/main/java/de/tum/cit/aet/analysis/service/AnalysisResultPersistenceService.java
+++ b/src/main/java/de/tum/cit/aet/analysis/service/AnalysisResultPersistenceService.java
@@ -266,6 +266,7 @@ public class AnalysisResultPersistenceService {
                     .analyzeRepositoryWithOrphans(repo, templateAuthorEmails);
             orphanCommits = analysisResult.orphanCommits();
         } catch (Exception e) {
+            restoreInterruptFlag(e);
             log.warn("Failed to detect orphan commits for team {}: {}", team.name(), e.getMessage());
         }
 
@@ -282,15 +283,17 @@ public class AnalysisResultPersistenceService {
                 analysisHistory = report.analyzedChunks();
                 cqiDetails = report.cqiResult();
                 fairnessSucceeded = true;
-
-                if (analysisHistory != null && !analysisHistory.isEmpty()) {
-                    saveAnalyzedChunks(teamParticipation, analysisHistory);
-                }
             } else {
                 log.warn("Fairness analysis returned error for team {}", team.name());
             }
         } catch (Exception e) {
+            restoreInterruptFlag(e);
             log.warn("Fairness analysis failed for team {}, falling back: {}", team.name(), e.getMessage());
+        }
+
+        // Interrupt check before fallback
+        if (Thread.currentThread().isInterrupted()) {
+            throw new RuntimeException(new InterruptedException("AI analysis cancelled for team " + team.name()));
         }
 
         // 3) Fallback: CQI calculator with pre-filtered commits
@@ -306,6 +309,7 @@ public class AnalysisResultPersistenceService {
                             team.name(), team.shortName(), exerciseId);
                     cqi = cqiDetails.cqi();
                 } catch (Exception e) {
+                    restoreInterruptFlag(e);
                     log.warn("Fallback CQI calculation failed for team {}: {}", team.name(), e.getMessage());
                 }
             }
@@ -320,43 +324,40 @@ public class AnalysisResultPersistenceService {
             }
         }
 
-        // 5) Persist CQI and component scores
-        teamParticipation.setCqi(cqi);
-        teamParticipation.setIsSuspicious(isSuspicious);
-        teamParticipation.setOrphanCommitCount(orphanCommits != null ? orphanCommits.size() : 0);
-        persistCqiComponents(teamParticipation, cqiDetails);
-        persistTeamTokenTotals(teamParticipation, teamTokenTotals);
-        teamParticipation.setAnalysisStatus(TeamAnalysisStatus.DONE);
-        teamParticipationRepository.save(teamParticipation);
-
-        // 6) Apply existing email mappings (may recalculate CQI)
-        if (analysisHistory != null && !analysisHistory.isEmpty()) {
-            applyExistingEmailMappings(teamParticipation, exerciseId);
+        // Interrupt check before persist
+        if (Thread.currentThread().isInterrupted()) {
+            throw new RuntimeException(new InterruptedException("AI analysis cancelled for team " + team.name()));
         }
 
-        // 7) Build response from post-mapping state
-        List<StudentAnalysisDTO> studentDtos = students.stream()
-                .map(s -> new StudentAnalysisDTO(s.getName(), s.getCommitCount(), s.getLinesAdded(),
-                        s.getLinesDeleted(), s.getLinesChanged()))
-                .toList();
+        // Capture effectively final values for lambda
+        final Double finalCqi = cqi;
+        final CQIResultDTO finalCqiDetails = cqiDetails;
+        final List<AnalyzedChunkDTO> finalAnalysisHistory = analysisHistory;
+        final List<OrphanCommitDTO> finalOrphanCommits = orphanCommits;
+        final LlmTokenTotalsDTO finalTeamTokenTotals = teamTokenTotals;
 
-        Tutor tutor = teamParticipation.getTutor();
-        CQIResultDTO finalCqiDetails = queryService.reconstructCqiDetails(teamParticipation, AnalysisMode.FULL);
-        if (finalCqiDetails == null) {
-            finalCqiDetails = cqiDetails;
-        }
-        Double finalCqi = finalCqiDetails != null ? finalCqiDetails.cqi()
-                : (teamParticipation.getCqi() != null ? teamParticipation.getCqi() : cqi);
+        // 5-7) Short transaction: persist all DB state atomically
+        transactionTemplate.executeWithoutResult(status -> {
+            teamParticipation.setCqi(finalCqi);
+            teamParticipation.setIsSuspicious(false);
+            teamParticipation.setOrphanCommitCount(finalOrphanCommits != null ? finalOrphanCommits.size() : 0);
+            persistCqiComponents(teamParticipation, finalCqiDetails);
+            persistTeamTokenTotals(teamParticipation, finalTeamTokenTotals);
+            teamParticipation.setAnalysisStatus(TeamAnalysisStatus.DONE);
+            TeamParticipation managedTp = teamParticipationRepository.save(teamParticipation);
 
-        return new ClientResponseWithUsage(
-                new ClientResponseDTO(
-                        tutor != null ? tutor.getName() : "Unassigned",
-                        team.id(), participation.id(), team.name(), team.shortName(),
-                        participation.submissionCount(),
-                        studentDtos, finalCqi, isSuspicious, TeamAnalysisStatus.DONE,
-                        finalCqiDetails, analysisHistory, orphanCommits,
-                        teamTokenTotals, teamParticipation.getOrphanCommitCount(), null, null),
-                teamTokenTotals);
+            // Save chunks and apply email mappings atomically with DONE status
+            if (finalAnalysisHistory != null && !finalAnalysisHistory.isEmpty()) {
+                saveAnalyzedChunks(managedTp, finalAnalysisHistory);
+                applyExistingEmailMappings(managedTp, exerciseId);
+            }
+        });
+
+        // Build response from fresh DB state (includes student mutations from email mappings)
+        TeamParticipation freshTp = teamParticipationRepository.findByParticipation(participation.id())
+                .orElseThrow();
+        ClientResponseDTO responseDto = queryService.mapParticipationToClientResponse(freshTp);
+        return new ClientResponseWithUsage(responseDto, teamTokenTotals);
     }
 
     // =====================================================================
@@ -525,86 +526,79 @@ public class AnalysisResultPersistenceService {
      */
     @Transactional
     public void applyExistingEmailMappings(TeamParticipation participation, Long exerciseId) {
-        try {
-            List<ExerciseEmailMapping> mappings = emailMappingRepository.findAllByExerciseId(exerciseId);
-            if (mappings.isEmpty()) {
-                return;
-            }
-            List<AnalyzedChunk> chunks = analyzedChunkRepository.findByParticipation(participation);
-            Map<String, List<AnalyzedChunk>> remappedByStudent = new HashMap<>();
+        List<ExerciseEmailMapping> mappings = emailMappingRepository.findAllByExerciseId(exerciseId);
+        if (mappings.isEmpty()) {
+            return;
+        }
+        List<AnalyzedChunk> chunks = analyzedChunkRepository.findByParticipation(participation);
+        Map<String, List<AnalyzedChunk>> remappedByStudent = new HashMap<>();
 
-            for (ExerciseEmailMapping mapping : mappings) {
-                String emailLower = mapping.getGitEmail().toLowerCase(Locale.ROOT);
-                for (AnalyzedChunk chunk : chunks) {
-                    if (Boolean.TRUE.equals(chunk.getIsExternalContributor())
-                            && emailLower.equals(chunk.getAuthorEmail() != null
-                            ? chunk.getAuthorEmail().toLowerCase(Locale.ROOT) : null)) {
-                        chunk.setIsExternalContributor(false);
-                        chunk.setAuthorName(mapping.getStudentName());
-                        remappedByStudent.computeIfAbsent(mapping.getStudentName(), k -> new ArrayList<>())
-                                .add(chunk);
+        for (ExerciseEmailMapping mapping : mappings) {
+            String emailLower = mapping.getGitEmail().toLowerCase(Locale.ROOT);
+            for (AnalyzedChunk chunk : chunks) {
+                if (Boolean.TRUE.equals(chunk.getIsExternalContributor())
+                        && emailLower.equals(chunk.getAuthorEmail() != null
+                        ? chunk.getAuthorEmail().toLowerCase(Locale.ROOT) : null)) {
+                    chunk.setIsExternalContributor(false);
+                    chunk.setAuthorName(mapping.getStudentName());
+                    remappedByStudent.computeIfAbsent(mapping.getStudentName(), k -> new ArrayList<>())
+                            .add(chunk);
+                }
+            }
+        }
+
+        if (!remappedByStudent.isEmpty()) {
+            analyzedChunkRepository.saveAll(chunks);
+
+            List<Student> students = studentRepository.findAllByTeam(participation);
+            for (Map.Entry<String, List<AnalyzedChunk>> entry : remappedByStudent.entrySet()) {
+                String studentName = entry.getKey();
+                int deltaCommits = 0;
+                int deltaLines = 0;
+                for (AnalyzedChunk chunk : entry.getValue()) {
+                    if (chunk.getCommitShas() != null && !chunk.getCommitShas().isEmpty()) {
+                        deltaCommits += chunk.getCommitShas().split(",").length;
+                    }
+                    deltaLines += chunk.getLinesChanged() != null ? chunk.getLinesChanged() : 0;
+                }
+                if (deltaCommits > 0 || deltaLines > 0) {
+                    int finalDeltaCommits = deltaCommits;
+                    int finalDeltaLines = deltaLines;
+                    students.stream()
+                            .filter(s -> studentName.equals(s.getName()))
+                            .findFirst()
+                            .ifPresent(student -> {
+                                student.setCommitCount(
+                                        (student.getCommitCount() != null ? student.getCommitCount() : 0)
+                                                + finalDeltaCommits);
+                                student.setLinesChanged(
+                                        (student.getLinesChanged() != null ? student.getLinesChanged() : 0)
+                                                + finalDeltaLines);
+                                CqiRecalculationService.applyLinesSplit(student, finalDeltaLines, true);
+                                studentRepository.save(student);
+                            });
+                }
+            }
+            cqiRecalculationService.recalculateFromChunks(participation, chunks);
+
+            // Recompute orphan commit count from remaining external-contributor chunks,
+            // but exclude template authors (they should not be considered "unmatched")
+            Set<String> templateAuthorEmails = templateAuthorRepository.findByExerciseId(exerciseId)
+                    .stream().map(ta -> ta.getTemplateEmail().toLowerCase(Locale.ROOT)).collect(Collectors.toSet());
+            int remainingOrphanCommits = 0;
+            for (AnalyzedChunk c : chunks) {
+                if (Boolean.TRUE.equals(c.getIsExternalContributor())) {
+                    String chunkEmail = c.getAuthorEmail() != null ? c.getAuthorEmail().toLowerCase(Locale.ROOT) : null;
+                    if (chunkEmail != null && templateAuthorEmails.contains(chunkEmail)) {
+                        continue;
+                    }
+                    if (c.getCommitShas() != null && !c.getCommitShas().isEmpty()) {
+                        remainingOrphanCommits += c.getCommitShas().split(",").length;
                     }
                 }
             }
-
-            if (!remappedByStudent.isEmpty()) {
-                analyzedChunkRepository.saveAll(chunks);
-
-                List<Student> students = studentRepository.findAllByTeam(participation);
-                for (Map.Entry<String, List<AnalyzedChunk>> entry : remappedByStudent.entrySet()) {
-                    String studentName = entry.getKey();
-                    int deltaCommits = 0;
-                    int deltaLines = 0;
-                    for (AnalyzedChunk chunk : entry.getValue()) {
-                        if (chunk.getCommitShas() != null && !chunk.getCommitShas().isEmpty()) {
-                            deltaCommits += chunk.getCommitShas().split(",").length;
-                        }
-                        deltaLines += chunk.getLinesChanged() != null ? chunk.getLinesChanged() : 0;
-                    }
-                    if (deltaCommits > 0 || deltaLines > 0) {
-                        int finalDeltaCommits = deltaCommits;
-                        int finalDeltaLines = deltaLines;
-                        students.stream()
-                                .filter(s -> studentName.equals(s.getName()))
-                                .findFirst()
-                                .ifPresent(student -> {
-                                    student.setCommitCount(
-                                            (student.getCommitCount() != null ? student.getCommitCount() : 0)
-                                                    + finalDeltaCommits);
-                                    student.setLinesChanged(
-                                            (student.getLinesChanged() != null ? student.getLinesChanged() : 0)
-                                                    + finalDeltaLines);
-                                    CqiRecalculationService.applyLinesSplit(student, finalDeltaLines, true);
-                                    studentRepository.save(student);
-                                });
-                    }
-                }
-                cqiRecalculationService.recalculateFromChunks(participation, chunks);
-
-                // Recompute orphan commit count from remaining external-contributor chunks,
-                // but exclude template authors (they should not be considered "unmatched")
-                Set<String> templateAuthorEmails = templateAuthorRepository.findByExerciseId(exerciseId)
-                        .stream().map(ta -> ta.getTemplateEmail().toLowerCase(Locale.ROOT)).collect(Collectors.toSet());
-                int remainingOrphanCommits = 0;
-                for (AnalyzedChunk c : chunks) {
-                    if (Boolean.TRUE.equals(c.getIsExternalContributor())) {
-                        String chunkEmail = c.getAuthorEmail() != null ? c.getAuthorEmail().toLowerCase(Locale.ROOT) : null;
-                        if (chunkEmail != null && templateAuthorEmails.contains(chunkEmail)) {
-                            // skip template authors
-                            continue;
-                        }
-                        if (c.getCommitShas() != null && !c.getCommitShas().isEmpty()) {
-                            remainingOrphanCommits += c.getCommitShas().split(",").length;
-                        }
-                    }
-                }
-                participation.setOrphanCommitCount(remainingOrphanCommits);
-                // persist updated participation so UI queries see new value
-                teamParticipationRepository.save(participation);
-            }
-        } catch (Exception e) {
-            log.warn("Failed to apply existing email mappings for team {}: {}",
-                    participation.getName(), e.getMessage());
+            participation.setOrphanCommitCount(remainingOrphanCommits);
+            teamParticipationRepository.save(participation);
         }
     }
 
@@ -760,6 +754,42 @@ public class AnalysisResultPersistenceService {
      */
     public boolean shouldSkipTeam(TeamParticipation tp) {
         return Boolean.TRUE.equals(tp.getIsFailed());
+    }
+
+    /**
+     * Atomically marks a team as ERROR and clears all AI-derived fields.
+     * Called from the pipeline on AI analysis failure to prevent orphaned state.
+     *
+     * @param participationId the Artemis participation ID
+     */
+    @Transactional
+    public void markTeamAsErrorAndClearAiResults(Long participationId) {
+        teamParticipationRepository.findByParticipation(participationId).ifPresent(tp -> {
+            tp.setAnalysisStatus(TeamAnalysisStatus.ERROR);
+            // Clear AI-derived fields only; preserve git-derived metrics
+            // (locBalance, temporalSpread, ownershipSpread, dailyDistribution, pairProgramming)
+            tp.setCqi(null);
+            tp.setCqiEffortBalance(null);
+            tp.setCqiBaseScore(null);
+            tp.setOrphanCommitCount(null);
+            tp.setLlmCalls(null);
+            tp.setLlmCallsWithUsage(null);
+            tp.setLlmPromptTokens(null);
+            tp.setLlmCompletionTokens(null);
+            tp.setLlmTotalTokens(null);
+            teamParticipationRepository.save(tp);
+            analyzedChunkRepository.deleteAllByParticipation(tp);
+        });
+    }
+
+    private void restoreInterruptFlag(Exception e) {
+        for (Throwable t = e; t != null; t = t.getCause()) {
+            if (t instanceof InterruptedException
+                    || t instanceof java.nio.channels.ClosedByInterruptException) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+        }
     }
 
     private TeamRepositoryDTO buildTeamRepositoryDTO(TeamParticipation tp, TeamRepository repo) {

--- a/src/main/java/de/tum/cit/aet/analysis/service/AnalysisTaskManager.java
+++ b/src/main/java/de/tum/cit/aet/analysis/service/AnalysisTaskManager.java
@@ -20,6 +20,9 @@ public class AnalysisTaskManager {
     /** Active download/git-analysis executors by exerciseId (for cancellation). */
     private final Map<Long, ExecutorService> activeExecutors = new ConcurrentHashMap<>();
 
+    /** Active AI-analysis executors by exerciseId (for cancellation). */
+    private final Map<Long, ExecutorService> activeAiExecutors = new ConcurrentHashMap<>();
+
     /** Main stream-analysis threads by exerciseId (for interrupt-based cancellation). */
     private final Map<Long, Thread> runningStreamTasks = new ConcurrentHashMap<>();
 
@@ -40,16 +43,9 @@ public class AnalysisTaskManager {
             future.cancel(true);
         }
 
-        // 2) Shut down the download/git-analysis executor
-        ExecutorService executor = activeExecutors.remove(exerciseId);
-        if (executor != null) {
-            executor.shutdownNow();
-            try {
-                executor.awaitTermination(2, TimeUnit.SECONDS);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            }
-        }
+        // 2) Shut down the download/git-analysis executor and the AI-analysis executor
+        shutdownTrackedExecutor(activeExecutors.remove(exerciseId));
+        shutdownTrackedExecutor(activeAiExecutors.remove(exerciseId));
 
         // 3) Interrupt the main stream thread (stops AI analysis phase)
         Thread streamThread = runningStreamTasks.remove(exerciseId);
@@ -94,6 +90,25 @@ public class AnalysisTaskManager {
 
     public void unregisterExecutor(Long exerciseId) {
         activeExecutors.remove(exerciseId);
+    }
+
+    public void registerAiExecutor(Long exerciseId, ExecutorService executor) {
+        activeAiExecutors.put(exerciseId, executor);
+    }
+
+    public void unregisterAiExecutor(Long exerciseId) {
+        activeAiExecutors.remove(exerciseId);
+    }
+
+    private void shutdownTrackedExecutor(ExecutorService executor) {
+        if (executor != null) {
+            executor.shutdownNow();
+            try {
+                executor.awaitTermination(2, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
     }
 
     public void registerStreamThread(Long exerciseId, Thread thread) {

--- a/src/main/java/de/tum/cit/aet/dataProcessing/service/ExerciseTeamLifecycleService.java
+++ b/src/main/java/de/tum/cit/aet/dataProcessing/service/ExerciseTeamLifecycleService.java
@@ -158,12 +158,13 @@ public class ExerciseTeamLifecycleService {
      */
     public void markPendingTeamsAsCancelled(Long exerciseId) {
         try {
-            List<TeamParticipation> pendingTeams = teamParticipationRepository
-                    .findAllByExerciseIdAndAnalysisStatus(exerciseId, TeamAnalysisStatus.PENDING);
-
-            for (TeamParticipation team : pendingTeams) {
-                team.setAnalysisStatus(TeamAnalysisStatus.CANCELLED);
-                teamParticipationRepository.save(team);
+            for (TeamAnalysisStatus status : List.of(TeamAnalysisStatus.PENDING, TeamAnalysisStatus.AI_ANALYZING)) {
+                List<TeamParticipation> teams = teamParticipationRepository
+                        .findAllByExerciseIdAndAnalysisStatus(exerciseId, status);
+                for (TeamParticipation team : teams) {
+                    team.setAnalysisStatus(TeamAnalysisStatus.CANCELLED);
+                    teamParticipationRepository.save(team);
+                }
             }
         } catch (Exception e) {
             log.error("Failed to mark pending teams as cancelled for exerciseId={}", exerciseId, e);

--- a/src/main/java/de/tum/cit/aet/dataProcessing/service/StreamingAnalysisPipelineService.java
+++ b/src/main/java/de/tum/cit/aet/dataProcessing/service/StreamingAnalysisPipelineService.java
@@ -19,6 +19,7 @@ import de.tum.cit.aet.repositoryProcessing.dto.*;
 import de.tum.cit.aet.repositoryProcessing.repository.TeamParticipationRepository;
 import de.tum.cit.aet.repositoryProcessing.service.GitOperationsService;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.support.TransactionTemplate;
 
@@ -55,6 +56,7 @@ public class StreamingAnalysisPipelineService {
     private final AnalysisResultPersistenceService persistenceService;
     private final PairProgrammingService pairProgrammingService;
     private final PairProgrammingRecomputeService pairProgrammingRecomputeService;
+    private final int aiParallelism;
 
     public StreamingAnalysisPipelineService(
             ArtemisClientService artemisClientService,
@@ -68,7 +70,8 @@ public class StreamingAnalysisPipelineService {
             ExerciseTeamLifecycleService exerciseDataCleanupService,
             AnalysisResultPersistenceService persistenceService,
             PairProgrammingService pairProgrammingService,
-            PairProgrammingRecomputeService pairProgrammingRecomputeService) {
+            PairProgrammingRecomputeService pairProgrammingRecomputeService,
+            @Value("${harmonia.ai.parallelism:4}") int aiParallelism) {
         this.artemisClientService = artemisClientService;
         this.gitOperationsService = gitOperationsService;
         this.analysisStateService = analysisStateService;
@@ -81,6 +84,7 @@ public class StreamingAnalysisPipelineService {
         this.persistenceService = persistenceService;
         this.pairProgrammingService = pairProgrammingService;
         this.pairProgrammingRecomputeService = pairProgrammingRecomputeService;
+        this.aiParallelism = aiParallelism;
     }
 
     // =====================================================================
@@ -162,6 +166,7 @@ public class StreamingAnalysisPipelineService {
         analysisTaskManager.registerStreamThread(exerciseId, Thread.currentThread());
 
         ExecutorService executor = null;
+        ExecutorService aiExecutor = null;
         try {
             // 1) Clear existing data for a clean slate
             transactionTemplate.executeWithoutResult(status ->
@@ -298,46 +303,8 @@ public class StreamingAnalysisPipelineService {
             if (mode == AnalysisMode.SIMPLE) {
                 finalizeSimpleMode(validParticipations, clonedRepos, exerciseId, eventEmitter);
             } else {
-                eventEmitter.accept(Map.of("type", "PHASE", "phase", "AI_ANALYSIS", "total", clonedRepos.size()));
-
-                AtomicInteger aiAnalyzedCount = new AtomicInteger(0);
-                LlmTokenTotalsDTO runTokenTotals = LlmTokenTotalsDTO.empty();
-
-                for (ParticipationDTO participation : validParticipations) {
-                    if (!analysisStateService.isRunning(exerciseId) || Thread.currentThread().isInterrupted()) {
-                        break;
-                    }
-
-                    TeamRepositoryDTO repo = clonedRepos.get(participation.id());
-                    if (repo == null) {
-                        aiAnalyzedCount.incrementAndGet();
-                        continue;
-                    }
-
-                    TeamParticipation tp = teamParticipationRepository.findByParticipation(participation.id()).orElse(null);
-                    if (tp != null && persistenceService.shouldSkipTeam(tp)) {
-                        aiAnalyzedCount.incrementAndGet();
-                        continue;
-                    }
-
-                    runTokenTotals = processAIAnalysis(participation, repo, exerciseId,
-                            aiAnalyzedCount, clonedRepos.size(), runTokenTotals, eventEmitter);
-                }
-
-                log.info("Phase 3 complete: AI analysis done for {} teams", aiAnalyzedCount.get());
-                log.info("LLM_USAGE scope=stream exerciseId={} teams={} llmCalls={} promptTokens={} completionTokens={} totalTokens={}",
-                        exerciseId, aiAnalyzedCount.get(),
-                        runTokenTotals.llmCalls(), runTokenTotals.promptTokens(),
-                        runTokenTotals.completionTokens(), runTokenTotals.totalTokens());
-
-                if (analysisStateService.isRunning(exerciseId)) {
-                    analysisStateService.completeAnalysis(exerciseId);
-                    eventEmitter.accept(Map.of("type", "DONE"));
-                } else {
-                    exerciseDataCleanupService.markPendingTeamsAsCancelled(exerciseId);
-                    eventEmitter.accept(Map.of("type", "CANCELLED",
-                            "processed", aiAnalyzedCount.get(), "total", totalToProcess));
-                }
+                aiExecutor = finalizeFullMode(validParticipations, clonedRepos, exerciseId,
+                        totalToProcess, eventEmitter);
             }
 
         } catch (RejectedExecutionException e) {
@@ -351,8 +318,10 @@ public class StreamingAnalysisPipelineService {
             eventEmitter.accept(Map.of("type", "ERROR", "message", e.getMessage()));
         } finally {
             analysisTaskManager.unregisterExecutor(exerciseId);
+            analysisTaskManager.unregisterAiExecutor(exerciseId);
             analysisTaskManager.unregisterStreamThread(exerciseId);
             shutdownExecutorQuietly(executor);
+            shutdownExecutorQuietly(aiExecutor);
         }
     }
 
@@ -488,7 +457,7 @@ public class StreamingAnalysisPipelineService {
     private LlmTokenTotalsDTO processAIAnalysis(ParticipationDTO participation, TeamRepositoryDTO repo,
                                               Long exerciseId,
                                               AtomicInteger aiAnalyzedCount,
-                                              int total, LlmTokenTotalsDTO runTokenTotals,
+                                              int total,
                                               Consumer<Object> eventEmitter) {
         String teamName = participation.team() != null ? participation.team().name() : "Unknown";
 
@@ -500,13 +469,9 @@ public class StreamingAnalysisPipelineService {
                         "teamId", participation.team().id(), "teamName", teamName));
             }
 
-            final TeamRepositoryDTO finalRepo = repo;
-            AnalysisResultPersistenceService.ClientResponseWithUsage aiResult = transactionTemplate
-                    .execute(status -> persistenceService.saveAIAnalysisResultWithUsage(finalRepo, exerciseId));
+            AnalysisResultPersistenceService.ClientResponseWithUsage aiResult =
+                    persistenceService.saveAIAnalysisResultWithUsage(repo, exerciseId);
             ClientResponseDTO aiDto = aiResult != null ? aiResult.response() : null;
-            if (aiResult != null) {
-                runTokenTotals = runTokenTotals.merge(aiResult.tokenTotals());
-            }
 
             int current = aiAnalyzedCount.incrementAndGet();
             analysisStateService.updateProgress(exerciseId, teamName, "DONE", current);
@@ -519,17 +484,25 @@ public class StreamingAnalysisPipelineService {
             log.debug("AI analysis {}/{}: {} (CQI={})", current, total,
                     teamName, aiDto != null ? aiDto.cqi() : "N/A");
 
+            return aiResult != null ? aiResult.tokenTotals() : LlmTokenTotalsDTO.empty();
+
         } catch (Exception e) {
-            log.error("Error in AI analysis for team {}", teamName, e);
-            aiAnalyzedCount.incrementAndGet();
-            analysisStateService.updateProgress(exerciseId, teamName, "AI_ERROR", aiAnalyzedCount.get());
-            synchronized (eventEmitter) {
-                eventEmitter.accept(Map.of("type", "AI_ERROR",
-                        "teamId", participation.team().id(), "teamName", teamName,
-                        "error", e.getMessage()));
+            if (Thread.currentThread().isInterrupted() || e.getCause() instanceof InterruptedException) {
+                log.info("AI analysis cancelled for team {}", teamName);
+                Thread.currentThread().interrupt();
+            } else {
+                log.error("Error in AI analysis for team {}", teamName, e);
+                aiAnalyzedCount.incrementAndGet();
+                persistenceService.markTeamAsErrorAndClearAiResults(participation.id());
+                analysisStateService.updateProgress(exerciseId, teamName, "AI_ERROR", aiAnalyzedCount.get());
+                synchronized (eventEmitter) {
+                    eventEmitter.accept(Map.of("type", "AI_ERROR",
+                            "teamId", participation.team().id(), "teamName", teamName,
+                            "error", e.getMessage()));
+                }
             }
+            return LlmTokenTotalsDTO.empty();
         }
-        return runTokenTotals;
     }
 
     private void finalizeSimpleMode(List<ParticipationDTO> validParticipations,
@@ -585,6 +558,84 @@ public class StreamingAnalysisPipelineService {
             eventEmitter.accept(Map.of("type", "CANCELLED",
                     "processed", processedCount.get(), "total", total));
         }
+    }
+
+    private ExecutorService finalizeFullMode(List<ParticipationDTO> validParticipations,
+                                                Map<Long, TeamRepositoryDTO> clonedRepos,
+                                                Long exerciseId, int totalToProcess,
+                                                Consumer<Object> eventEmitter) {
+        record AiCandidate(ParticipationDTO participation, TeamRepositoryDTO repo) {}
+        List<AiCandidate> aiCandidates = new ArrayList<>();
+        for (ParticipationDTO participation : validParticipations) {
+            TeamRepositoryDTO repo = clonedRepos.get(participation.id());
+            if (repo == null) {
+                continue;
+            }
+            TeamParticipation tp = teamParticipationRepository
+                    .findByParticipation(participation.id()).orElse(null);
+            if (tp != null && persistenceService.shouldSkipTeam(tp)) {
+                continue;
+            }
+            aiCandidates.add(new AiCandidate(participation, repo));
+        }
+
+        int aiTotal = aiCandidates.size();
+        eventEmitter.accept(Map.of("type", "PHASE", "phase", "AI_ANALYSIS", "total", aiTotal));
+
+        AtomicInteger aiAnalyzedCount = new AtomicInteger(0);
+        ConcurrentLinkedQueue<LlmTokenTotalsDTO> tokenBag = new ConcurrentLinkedQueue<>();
+
+        int aiThreadCount = Math.max(1, Math.min(aiTotal, aiParallelism));
+        ExecutorService aiExecutor = Executors.newFixedThreadPool(aiThreadCount);
+        analysisTaskManager.registerAiExecutor(exerciseId, aiExecutor);
+
+        CountDownLatch aiLatch = new CountDownLatch(aiTotal);
+
+        for (AiCandidate candidate : aiCandidates) {
+            aiExecutor.submit(() -> {
+                try {
+                    if (!analysisStateService.isRunning(exerciseId)) {
+                        return;
+                    }
+                    LlmTokenTotalsDTO teamTokens = processAIAnalysis(
+                            candidate.participation(), candidate.repo(), exerciseId,
+                            aiAnalyzedCount, aiTotal, eventEmitter);
+                    tokenBag.add(teamTokens);
+                } catch (Exception e) {
+                    log.error("Unexpected error in AI analysis thread for participation {}",
+                            candidate.participation().id(), e);
+                } finally {
+                    aiLatch.countDown();
+                }
+            });
+        }
+
+        try {
+            aiLatch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.info("AI analysis phase interrupted for exerciseId={}", exerciseId);
+        }
+
+        LlmTokenTotalsDTO runTokenTotals = tokenBag.stream()
+                .reduce(LlmTokenTotalsDTO.empty(), LlmTokenTotalsDTO::merge);
+
+        log.info("Phase 3 complete: AI analysis done for {} teams", aiAnalyzedCount.get());
+        log.info("LLM_USAGE scope=stream exerciseId={} teams={} llmCalls={} promptTokens={} completionTokens={} totalTokens={}",
+                exerciseId, aiAnalyzedCount.get(),
+                runTokenTotals.llmCalls(), runTokenTotals.promptTokens(),
+                runTokenTotals.completionTokens(), runTokenTotals.totalTokens());
+
+        if (analysisStateService.isRunning(exerciseId)) {
+            analysisStateService.completeAnalysis(exerciseId);
+            eventEmitter.accept(Map.of("type", "DONE"));
+        } else {
+            exerciseDataCleanupService.markPendingTeamsAsCancelled(exerciseId);
+            eventEmitter.accept(Map.of("type", "CANCELLED",
+                    "processed", aiAnalyzedCount.get(), "total", totalToProcess));
+        }
+
+        return aiExecutor;
     }
 
     private void emitPendingTeams(List<ParticipationDTO> validParticipations,

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -49,6 +49,7 @@ harmonia:
       - "http://localhost:3000"
       - "http://localhost:8080"
   ai:
+    parallelism: 4
     enabled: true
     commit-classifier:
       enabled: true

--- a/src/test/java/de/tum/cit/aet/dataProcessing/service/RequestServiceApplyMappingsTest.java
+++ b/src/test/java/de/tum/cit/aet/dataProcessing/service/RequestServiceApplyMappingsTest.java
@@ -27,12 +27,14 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -55,6 +57,7 @@ class RequestServiceApplyMappingsTest {
     @Mock private CqiRecalculationService cqiRecalculationService;
     @Mock private ExerciseTeamLifecycleService cleanupService;
     @Mock private AnalysisQueryService queryService;
+    @Mock private TransactionTemplate transactionTemplate;
 
     @Captor private ArgumentCaptor<List<AnalyzedChunk>> chunksCaptor;
 
@@ -68,7 +71,7 @@ class RequestServiceApplyMappingsTest {
                 cqiRecalculationService, null,
                 null, teamParticipationRepository, studentRepository,
                 analyzedChunkRepository, templateAuthorRepository, emailMappingRepository,
-                cleanupService, queryService, null);
+                cleanupService, queryService, transactionTemplate);
     }
 
     // ── Unit tests for applyExistingEmailMappings ──────────────────────────
@@ -175,7 +178,14 @@ class RequestServiceApplyMappingsTest {
     // ── Integration test: saveAIAnalysisResultWithUsage calls applyExistingEmailMappings ──
 
     @Test
+    @SuppressWarnings("unchecked")
     void saveAIAnalysisResultWithUsage_withExistingMapping_appliesMappingToSavedChunks() {
+        // Make transactionTemplate.executeWithoutResult actually run the callback
+        doAnswer(inv -> {
+            inv.getArgument(0, Consumer.class).accept(null);
+            return null;
+        }).when(transactionTemplate).executeWithoutResult(any());
+
         Long exerciseId = 42L;
 
         // Build a minimal TeamRepositoryDTO
@@ -215,7 +225,7 @@ class RequestServiceApplyMappingsTest {
                 "Team Alpha", 75.0, Map.of(), Map.of(),
                 false, List.of(), null,
                 List.of(externalChunkDTO), null);
-        when(fairnessService.analyzeFairnessWithUsage(eq(repo), eq(Set.of()), null))
+        when(fairnessService.analyzeFairnessWithUsage(eq(repo), eq(Set.of()), isNull()))
                 .thenReturn(new FairnessReportWithUsageDTO(fairnessReport, LlmTokenTotalsDTO.empty()));
 
         // saveAll for chunks: capture and return the same list


### PR DESCRIPTION
### Checklist

#### General

- [ ] I tested **all** changes and their related features with **all** corresponding user types.

#### Server

- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the server coding and design guidelines.
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context

Phase 3 (AI analysis) of the streaming pipeline ran sequentially — each team was sent through the LLM one at a time. With 50+ teams this was the largest bottleneck, taking significantly longer than the already-parallel Phase 1 (download) and Phase 2 (git analysis).

### Description

Parallelizes Phase 3 analogously to Phase 1 & 2 using a dedicated \`ExecutorService\` with configurable thread count (\`harmonia.ai.parallelism\`, default 4).

**Key changes:**

| File | Change |
|------|--------|
| \`StreamingAnalysisPipelineService\` | Phase 3 worklist pre-filtering, parallel executor with \`CountDownLatch\`, token aggregation via \`ConcurrentLinkedQueue\`, extracted \`finalizeFullMode()\` for symmetry with \`finalizeSimpleMode()\` |
| \`AnalysisResultPersistenceService\` | TX boundary moved here: short \`transactionTemplate.executeWithoutResult()\` atomically persists CQI + chunks + email mappings. Interrupt checks before fallback and persist. \`restoreInterruptFlag()\` walks full cause chain. \`applyExistingEmailMappings\` no longer swallows exceptions. Response built from fresh DB state. New \`markTeamAsErrorAndClearAiResults()\` clears only AI-derived fields |
| \`AnalysisTaskManager\` | Separate AI executor tracking (\`registerAiExecutor\`/\`unregisterAiExecutor\`), shutdown in \`stopAnalysis()\`, extracted \`shutdownTrackedExecutor()\` helper |
| \`ExerciseTeamLifecycleService\` | \`markPendingTeamsAsCancelled\` also marks \`AI_ANALYZING\` teams |
| \`application.yml\` | \`harmonia.ai.parallelism: 4\` |

**Cancellation handling:**
- \`stopAnalysis()\` shuts down the AI executor via \`shutdownNow()\`
- Interrupt flag is restored in all catch blocks via \`restoreInterruptFlag()\` (walks full cause chain)
- Cancellation vs. real error distinguished in \`processAIAnalysis\` — cancellation does not emit \`AI_ERROR\` events

**Accepted trade-offs (deferred):**
- Optimistic locking on \`TeamParticipation\` — low risk, separate PR
- LLM rate limiting via Semaphore — thread pool size acts as natural limiter

### Steps for Testing

Prerequisites:

1. Log in to Harmonia
2. Navigate to an exercise with 10+ teams

**Parallel execution:**
3. Start a FULL analysis
4. Observe that multiple \`AI_ANALYZING\` SSE events arrive concurrently (not sequentially)
5. Verify all teams reach \`DONE\` with valid CQI scores

**Cancellation:**
6. Start a FULL analysis, cancel mid-way through Phase 3
7. Verify no teams are stuck in \`AI_ANALYZING\` — they should be \`CANCELLED\`
8. Verify no orphaned chunks remain in the database

**Error recovery:**
9. If a single team fails AI analysis, verify other teams complete normally
10. Verify the failed team shows \`ERROR\` status with git metrics preserved

### Review Progress

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Test 1

### Test Coverage

| Class/File | Line Coverage | Confirmation (assert/expect) |
|---|---:|---:|
| RequestServiceApplyMappingsTest.java | updated for new TX boundary | ✅ |